### PR TITLE
Add REST provider to Express framework bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Here's an example of a Feathers server that uses `@feathersjs/express`.
 
 ```js
 const feathers = require('feathers');
-const expressify = require('@feathersjs/express');
+const express = require('@feathersjs/express');
 
-const app = expressify(feathers());
+const app = express(feathers());
 
+app.configure(express.rest());
 app.use('/myservice', {
   get(id) {
     return Promise.resolve({ id });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
-const debug = require('debug')('@feathersjs/express');
 const express = require('express');
 const Proto = require('uberproto');
+const debug = require('debug')('feathersjs/express');
+
+const rest = require('./rest');
 
 module.exports = function feathersExpress (feathersApp) {
   if (!feathersApp || typeof feathersApp.setup !== 'function') {
@@ -73,4 +75,4 @@ module.exports = function feathersExpress (feathersApp) {
   return Proto.mixin(mixin, expressApp);
 };
 
-Object.assign(module.exports, express);
+Object.assign(module.exports, express, { rest });

--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -1,0 +1,77 @@
+const makeDebug = require('debug');
+const wrappers = require('./wrappers');
+
+const debug = makeDebug('feathersjs/express/rest');
+
+function formatter (req, res, next) {
+  if (res.data === undefined) {
+    return next();
+  }
+
+  res.format({
+    'application/json': function () {
+      res.json(res.data);
+    }
+  });
+}
+
+function rest (handler = formatter) {
+  return function () {
+    const app = this;
+
+    if (typeof app.route !== 'function') {
+      throw new Error('feathers-rest needs an Express compatible app. Feathers apps have to wrapped with feathers-express first.');
+    }
+
+    if (!app.version || app.version < '3.0.0') {
+      throw new Error(`feathers-rest requires an instance of a Feathers application version 3.x or later (got ${app.version})`);
+    }
+
+    app.rest = wrappers;
+
+    app.use(function (req, res, next) {
+      req.feathers = { provider: 'rest' };
+      next();
+    });
+
+    // Register the REST provider
+    app.providers.push(function (service, path, options) {
+      const uri = `/${path}`;
+      const baseRoute = app.route(uri);
+      const idRoute = app.route(`${uri}/:__feathersId`);
+
+      let { middleware } = options;
+      let { before, after } = middleware;
+
+      if (typeof handler === 'function') {
+        after = after.concat(handler);
+      }
+
+      debug(`Adding REST provider for service \`${path}\` at base route \`${uri}\``);
+
+      // GET / -> service.find(params)
+      baseRoute.get(...before, app.rest.find(service), ...after);
+      // POST / -> service.create(data, params)
+      baseRoute.post(...before, app.rest.create(service), ...after);
+      // PATCH / -> service.patch(null, data, params)
+      baseRoute.patch(...before, app.rest.patch(service), ...after);
+      // PUT / -> service.update(null, data, params)
+      baseRoute.put(...before, app.rest.update(service), ...after);
+      // DELETE / -> service.remove(null, params)
+      baseRoute.delete(...before, app.rest.remove(service), ...after);
+
+      // GET /:id -> service.get(id, params)
+      idRoute.get(...before, app.rest.get(service), ...after);
+      // PUT /:id -> service.update(id, data, params)
+      idRoute.put(...before, app.rest.update(service), ...after);
+      // PATCH /:id -> service.patch(id, data, params)
+      idRoute.patch(...before, app.rest.patch(service), ...after);
+      // DELETE /:id -> service.remove(id, params)
+      idRoute.delete(...before, app.rest.remove(service), ...after);
+    });
+  };
+}
+
+rest.formatter = formatter;
+
+module.exports = rest;

--- a/lib/rest/wrappers.js
+++ b/lib/rest/wrappers.js
@@ -1,0 +1,115 @@
+const errors = require('@feathersjs/errors');
+const { omit } = require('@feathersjs/commons')._;
+
+const debug = require('debug')('feathersjs/express/rest');
+
+const statusCodes = {
+  created: 201,
+  noContent: 204,
+  methodNotAllowed: 405
+};
+const methodMap = {
+  find: 'GET',
+  get: 'GET',
+  create: 'POST',
+  update: 'PUT',
+  patch: 'PATCH',
+  remove: 'DELETE'
+};
+const allowedMethods = function (service) {
+  return Object.keys(methodMap)
+    .filter(method => typeof service[method] === 'function')
+    .map(method => methodMap[method])
+    // Filter out duplicates
+    .filter((value, index, list) => list.indexOf(value) === index);
+};
+
+// A function that returns the middleware for a given method and service
+// `getArgs` is a function that should return additional leading service arguments
+function getHandler (method, getArgs) {
+  return service => {
+    return function (req, res, next) {
+      const { query } = req;
+      const route = omit(req.params, '__feathersId');
+
+      res.setHeader('Allow', allowedMethods(service).join(','));
+
+      // Check if the method exists on the service at all. Send 405 (Method not allowed) if not
+      if (typeof service[method] !== 'function') {
+        debug(`Method '${method}' not allowed on '${req.url}'`);
+        res.status(statusCodes.methodNotAllowed);
+
+        return next(new errors.MethodNotAllowed(`Method \`${method}\` is not supported by this endpoint.`));
+      }
+
+      // Grab the service parameters. Use req.feathers
+      // and set the query to req.query merged with req.params
+      const params = Object.assign({
+        query, route
+      }, req.feathers);
+
+      Object.defineProperty(params, '__returnHook', {
+        value: true
+      });
+
+      // Run the getArgs callback, if available, for additional parameters
+      const args = getArgs(req, params);
+
+      debug(`REST handler calling \`${method}\` from \`${req.url}\``);
+
+      service[method](...args)
+        .then(hook => {
+          const data = hook.dispatch !== undefined ? hook.dispatch : hook.result;
+
+          res.data = data;
+          res.hook = hook;
+
+          if (!data) {
+            debug(`No content returned for '${req.url}'`);
+            res.status(statusCodes.noContent);
+          } else if (method === 'create') {
+            res.status(statusCodes.created);
+          }
+
+          return next();
+        })
+        .catch(hook => {
+          const { error } = hook;
+
+          debug(`Error in handler: \`${error.message}\``);
+          res.hook = hook;
+
+          return next(hook.error);
+        });
+    };
+  };
+}
+
+// Returns no leading parameters
+function reqNone (req, params) {
+  return [ params ];
+}
+
+// Returns the leading parameters for a `get` or `remove` request (the id)
+function reqId (req, params) {
+  return [ req.params.__feathersId || null, params ];
+}
+
+// Returns the leading parameters for an `update` or `patch` request (id, data)
+function reqUpdate (req, params) {
+  return [ req.params.__feathersId || null, req.body, params ];
+}
+
+// Returns the leading parameters for a `create` request (data)
+function reqCreate (req, params) {
+  return [ req.body, params ];
+}
+
+module.exports = {
+  find: getHandler('find', reqNone),
+  get: getHandler('get', reqId),
+  create: getHandler('create', reqCreate),
+  update: getHandler('update', reqUpdate),
+  patch: getHandler('patch', reqUpdate),
+  remove: getHandler('remove', reqId)
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,15 @@
     "@feathersjs/commons": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-1.0.0.tgz",
-      "integrity": "sha512-se02pGZTrH383iBWieDLuGt8zTt4YnIa0Y+VpwjJeTFGH10rwV0oHlnEfut4jxeBTqy1kWGyyODeLDjmGG6bsg==",
-      "dev": true
+      "integrity": "sha512-se02pGZTrH383iBWieDLuGt8zTt4YnIa0Y+VpwjJeTFGH10rwV0oHlnEfut4jxeBTqy1kWGyyODeLDjmGG6bsg=="
+    },
+    "@feathersjs/errors": {
+      "version": "3.0.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.0.0-pre.1.tgz",
+      "integrity": "sha512-kePJDUO9u+MJPnd9AUtGcpJfqR+l7+3asYRq4+r2IeObv3zMTKh7q31WvGUTF/FxCcCsy8oMmQ0aQ4f4IdI6HA==",
+      "requires": {
+        "debug": "3.1.0"
+      }
     },
     "@feathersjs/feathers": {
       "version": "3.0.0-pre.2",
@@ -690,12 +697,6 @@
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
-    },
-    "es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
-      "dev": true
     },
     "es6-set": {
       "version": "0.1.5",
@@ -2457,25 +2458,6 @@
         "glob": "7.1.2",
         "interpret": "1.0.3",
         "rechoir": "0.6.2"
-      }
-    },
-    "shx": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.2.2.tgz",
-      "integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
-      "dev": true,
-      "requires": {
-        "es6-object-assign": "1.1.0",
-        "minimist": "1.2.0",
-        "shelljs": "0.7.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "lib": "lib"
   },
   "dependencies": {
+    "@feathersjs/commons": "^1.0.0",
+    "@feathersjs/errors": "^3.0.0-pre.1",
     "debug": "^3.1.0",
     "express": "^4.16.2",
     "uberproto": "^1.2.0"

--- a/rest.js
+++ b/rest.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/rest');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,7 @@
 const assert = require('assert');
-
 const express = require('express');
-const feathers = require('@feathersjs/feathers');
 const axios = require('axios');
+const feathers = require('@feathersjs/feathers');
 
 const expressify = require('../lib');
 
@@ -17,6 +16,10 @@ describe('@feathersjs/express', () => {
     const app = expressify(feathers());
 
     assert.equal(typeof app, 'function');
+  });
+
+  it('exports `express.rest`', () => {
+    assert.ok(typeof expressify.rest === 'function');
   });
 
   it('errors when not app is provided', () => {

--- a/test/rest/crud.js
+++ b/test/rest/crud.js
@@ -1,0 +1,102 @@
+const assert = require('assert');
+const axios = require('axios');
+const { verify } = require('@feathersjs/commons/lib/test/fixture');
+
+module.exports = function crud (description, name) {
+  describe(description, () => {
+    it('GET .find', () => {
+      return axios.get(`http://localhost:4777/${name}`)
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.find(res.data);
+        });
+    });
+
+    it('GET .get', () => {
+      return axios.get('http://localhost:4777/todo/dishes')
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.get('dishes', res.data);
+        });
+    });
+
+    it('POST .create', () => {
+      let original = {
+        description: 'POST .create'
+      };
+
+      return axios.post(`http://localhost:4777/${name}`, original)
+        .then(res => {
+          assert.ok(res.status === 201, 'Got CREATED status code');
+          verify.create(original, res.data);
+        });
+    });
+
+    it('PUT .update', () => {
+      let original = {
+        description: 'PUT .update'
+      };
+
+      return axios.put('http://localhost:4777/todo/544', original)
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.update(544, original, res.data);
+        });
+    });
+
+    it('PUT .update many', () => {
+      let original = {
+        description: 'PUT .update',
+        many: true
+      };
+
+      return axios.put(`http://localhost:4777/${name}`, original)
+        .then(res => {
+          const { data } = res;
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.update(null, original, data);
+        });
+    });
+
+    it('PATCH .patch', () => {
+      let original = {
+        description: 'PATCH .patch'
+      };
+
+      return axios.patch('http://localhost:4777/todo/544', original)
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.patch(544, original, res.data);
+        });
+    });
+
+    it('PATCH .patch many', () => {
+      let original = {
+        description: 'PATCH .patch',
+        many: true
+      };
+
+      return axios.patch(`http://localhost:4777/${name}`, original)
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.patch(null, original, res.data);
+        });
+    });
+
+    it('DELETE .remove', () => {
+      return axios.delete('http://localhost:4777/tasks/233')
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.remove(233, res.data);
+        });
+    });
+
+    it('DELETE .remove many', () => {
+      return axios.delete('http://localhost:4777/tasks')
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          verify.remove(null, res.data);
+        });
+    });
+  });
+};

--- a/test/rest/index.test.js
+++ b/test/rest/index.test.js
@@ -1,0 +1,461 @@
+const assert = require('assert');
+const axios = require('axios');
+const bodyParser = require('body-parser');
+
+const feathers = require('@feathersjs/feathers');
+const { Service } = require('@feathersjs/commons/lib/test/fixture');
+
+const expressify = require('../../lib');
+const testCrud = require('./crud');
+const { rest } = expressify;
+
+describe('@feathersjs/express/rest provider', () => {
+  describe('base functionality', () => {
+    it('throws an error if you did not expressify', () => {
+      const app = feathers();
+
+      try {
+        app.configure(rest());
+        assert.ok(false, 'Should never get here');
+      } catch (e) {
+        assert.equal(e.message, 'feathers-rest needs an Express compatible app. Feathers apps have to wrapped with feathers-express first.');
+      }
+    });
+
+    it('throws an error for incompatible Feathers version', () => {
+      try {
+        const app = expressify(feathers());
+
+        app.version = '2.9.9';
+        app.configure(rest());
+
+        assert.ok(false, 'Should never get here');
+      } catch (e) {
+        assert.equal(e.message, 'feathers-rest requires an instance of a Feathers application version 3.x or later (got 2.9.9)');
+      }
+    });
+
+    it('lets you set the handler manually', () => {
+      const app = expressify(feathers());
+      const formatter = function (req, res) {
+        res.format({
+          'text/plain': function () {
+            res.end(`The todo is: ${res.data.description}`);
+          }
+        });
+      };
+
+      app.configure(rest(formatter))
+        .use('/todo', {
+          get (id) {
+            return Promise.resolve({
+              description: `You have to do ${id}`
+            });
+          }
+        });
+
+      let server = app.listen(4776);
+
+      return axios.get('http://localhost:4776/todo/dishes')
+        .then(res => {
+          assert.equal(res.data, 'The todo is: You have to do dishes');
+        })
+        .then(() => server.close());
+    });
+
+    it('lets you set no handler', () => {
+      const app = expressify(feathers());
+      const data = { fromHandler: true };
+
+      app.configure(rest(null))
+        .use('/todo', {
+          get (id) {
+            return Promise.resolve({
+              description: `You have to do ${id}`
+            });
+          }
+        })
+        .use((req, res) => res.json(data));
+
+      let server = app.listen(5775);
+
+      return axios.get('http://localhost:5775/todo-handler/dishes')
+        .then(res => assert.deepEqual(res.data, data))
+        .then(() => server.close());
+    });
+  });
+
+  describe('CRUD', () => {
+    let server, app;
+
+    before(function () {
+      app = expressify(feathers())
+        .configure(rest(rest.formatter))
+        .use(bodyParser.json())
+        .use('codes', {
+          get (id, params) {
+            return Promise.resolve({ id });
+          },
+
+          create (data) {
+            return Promise.resolve(data);
+          }
+        })
+        .use('todo', Service);
+
+      server = app.listen(4777, () => app.use('tasks', Service));
+    });
+
+    after(done => server.close(done));
+
+    testCrud('Services', 'todo');
+    testCrud('Dynamic Services', 'tasks');
+
+    describe('res.hook', () => {
+      const convertHook = hook => {
+        const result = Object.assign({}, hook);
+
+        delete result.service;
+        delete result.app;
+
+        return result;
+      };
+
+      it('sets the actual hook object in res.hook', () => {
+        app.use('/hook', {
+          get (id) {
+            return Promise.resolve({
+              description: `You have to do ${id}`
+            });
+          }
+        }, function (req, res, next) {
+          res.data = convertHook(res.hook);
+
+          next();
+        });
+
+        app.service('hook').hooks({
+          after (hook) {
+            hook.addedProperty = true;
+          }
+        });
+
+        return axios.get('http://localhost:4777/hook/dishes?test=param')
+          .then(res => {
+            assert.deepEqual(res.data, {
+              id: 'dishes',
+              params: {
+                route: {},
+                query: { test: 'param' },
+                provider: 'rest'
+              },
+              type: 'after',
+              method: 'get',
+              path: 'hook',
+              result: { description: 'You have to do dishes' },
+              addedProperty: true
+            });
+          });
+      });
+
+      it('can use hook.dispatch', () => {
+        app.use('/hook-dispatch', {
+          get (id) {
+            return Promise.resolve({});
+          }
+        });
+
+        app.service('hook-dispatch').hooks({
+          after (hook) {
+            hook.dispatch = {
+              id: hook.id,
+              fromDispatch: true
+            };
+          }
+        });
+
+        return axios.get('http://localhost:4777/hook-dispatch/dishes')
+          .then(res => {
+            assert.deepEqual(res.data, {
+              id: 'dishes',
+              fromDispatch: true
+            });
+          });
+      });
+
+      it('sets the hook object in res.hook on error', () => {
+        app.use('/hook-error', {
+          get () {
+            return Promise.reject(new Error('I blew up'));
+          }
+        }, function (error, req, res, next) {
+          res.status(500);
+          res.json({
+            hook: convertHook(res.hook),
+            error: {
+              message: error.message
+            }
+          });
+        });
+
+        return axios('http://localhost:4777/hook-error/dishes')
+          .catch(error => {
+            assert.deepEqual(error.response.data, {
+              hook: {
+                id: 'dishes',
+                params: {
+                  route: {},
+                  query: {},
+                  provider: 'rest'
+                },
+                type: 'error',
+                method: 'get',
+                path: 'hook-error',
+                result: null,
+                error: {}
+              },
+              error: { message: 'I blew up' }
+            });
+          });
+      });
+    });
+  });
+
+  describe('middleware', () => {
+    it('sets service parameters and provider type', () => {
+      let service = {
+        get (id, params) {
+          return Promise.resolve(params);
+        }
+      };
+
+      let server = expressify(feathers())
+        .configure(rest(rest.formatter))
+        .use(function (req, res, next) {
+          assert.ok(req.feathers, 'Feathers object initialized');
+          req.feathers.test = 'Happy';
+          next();
+        })
+        .use('service', service)
+        .listen(4778);
+
+      return axios.get('http://localhost:4778/service/bla?some=param&another=thing')
+        .then(res => {
+          let expected = {
+            test: 'Happy',
+            provider: 'rest',
+            route: {},
+            query: {
+              some: 'param',
+              another: 'thing'
+            }
+          };
+
+          assert.ok(res.status === 200, 'Got OK status code');
+          assert.deepEqual(res.data, expected, 'Got params object back');
+        })
+        .then(() => server.close());
+    });
+
+    it('Lets you configure your own middleware before the handler (#40)', () => {
+      const data = {
+        description: 'Do dishes!',
+        id: 'dishes'
+      };
+      const app = expressify(feathers());
+
+      app.use(function defaultContentTypeMiddleware (req, res, next) {
+        req.headers['content-type'] = req.headers['content-type'] || 'application/json';
+        next();
+      })
+      .configure(rest(rest.formatter))
+      .use(bodyParser.json())
+      .use('/todo', {
+        create (data) {
+          return Promise.resolve(data);
+        }
+      });
+
+      const server = app.listen(4775);
+      const options = {
+        url: 'http://localhost:4775/todo',
+        method: 'post',
+        data,
+        headers: {
+          'content-type': ''
+        }
+      };
+
+      return axios(options)
+        .then(res => {
+          assert.deepEqual(res.data, data);
+          server.close();
+        });
+    });
+
+    it('allows middleware before and after a service', () => {
+      const app = expressify(feathers());
+
+      app.configure(rest())
+        .use(bodyParser.json())
+        .use('/todo', function (req, res, next) {
+          req.body.before = [ 'before first' ];
+          next();
+        }, function (req, res, next) {
+          req.body.before.push('before second');
+          next();
+        }, {
+          create (data) {
+            return Promise.resolve(data);
+          }
+        }, function (req, res, next) {
+          res.data.after = [ 'after first' ];
+          next();
+        }, function (req, res, next) {
+          res.data.after.push('after second');
+          next();
+        });
+
+      const server = app.listen(4776);
+
+      return axios.post('http://localhost:4776/todo', { text: 'Do dishes' })
+        .then(res => {
+          assert.deepEqual(res.data, {
+            text: 'Do dishes',
+            before: [ 'before first', 'before second' ],
+            after: [ 'after first', 'after second' ]
+          });
+        })
+        .then(() => server.close());
+    });
+
+    it('formatter does nothing when there is no res.data', () => {
+      const data = { message: 'It worked' };
+      const app = expressify(feathers()).use('/test',
+        rest.formatter,
+        (req, res) => res.json(data)
+      );
+
+      const server = app.listen(7988);
+
+      return axios.get('http://localhost:7988/test')
+        .then(res => assert.deepEqual(res.data, data))
+        .then(() => server.close());
+    });
+  });
+
+  describe('HTTP status codes', () => {
+    let app, server;
+
+    before(function () {
+      app = expressify(feathers())
+        .configure(rest(rest.formatter))
+        .use('todo', {
+          get (id) {
+            return Promise.resolve({
+              description: `You have to do ${id}`
+            });
+          },
+
+          patch () {
+            return Promise.reject(new Error('Not implemented'));
+          },
+
+          find () {
+            return Promise.resolve(null);
+          }
+        });
+
+      app.use(function (req, res, next) {
+        if (typeof res.data !== 'undefined') {
+          next(new Error('Should never get here'));
+        } else {
+          next();
+        }
+      });
+
+      // Error handler
+      app.use(function (error, req, res, next) {
+        if (res.statusCode < 400) {
+          res.status(500);
+        }
+
+        res.json({ message: error.message });
+      });
+
+      server = app.listen(4780);
+    });
+
+    after(done => server.close(done));
+
+    it('throws a 405 for undefined service methods and sets Allow header (#99)', () => {
+      return axios.get('http://localhost:4780/todo/dishes')
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code for .get');
+          assert.deepEqual(res.data, {
+            description: 'You have to do dishes'
+          }, 'Got expected object');
+
+          return axios.post('http://localhost:4780/todo');
+        })
+        .catch(error => {
+          assert.equal(error.response.headers.allow, 'GET,PATCH');
+          assert.ok(error.response.status === 405, 'Got 405 for .create');
+          assert.deepEqual(error.response.data, {
+            message: 'Method `create` is not supported by this endpoint.'
+          }, 'Error serialized as expected');
+        });
+    });
+
+    it('throws a 404 for undefined route', () => {
+      return axios.get('http://localhost:4780/todo/foo/bar')
+        .catch(error => {
+          assert.ok(error.response.status === 404, 'Got Not Found code');
+        });
+    });
+
+    it('empty response sets 204 status codes, does not run other middleware (#391)', () => {
+      return axios.get('http://localhost:4780/todo')
+        .then(res => {
+          assert.ok(res.status === 204, 'Got empty status code');
+        });
+    });
+  });
+
+  describe('route parameters', () => {
+    let server, app;
+
+    before(() => {
+      app = expressify(feathers())
+        .configure(rest())
+        .use('/:appId/:id/todo', {
+          get (id, params) {
+            return Promise.resolve({
+              id,
+              route: params.route
+            });
+          }
+        });
+
+      server = app.listen(6880);
+    });
+
+    after(done => server.close(done));
+
+    it('adds route params as `params.route` and allows id property (#76, #407)', () => {
+      const expected = {
+        id: 'dishes',
+        route: {
+          appId: 'theApp',
+          id: 'myId'
+        }
+      };
+
+      return axios.get(`http://localhost:6880/theApp/myId/todo/${expected.id}`)
+        .then(res => {
+          assert.ok(res.status === 200, 'Got OK status code');
+          assert.deepEqual(expected, res.data);
+        });
+    });
+  });
+});


### PR DESCRIPTION
Since we are moving to npm scopes already having a drop-in for `feathers-rest` isn't necessary anymore. As discussed in #3 it makes much more sense for each framework to have their own REST provider so we might as well do that now.