### PR TITLE
Re-export Express error handler

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -1,0 +1,1 @@
+module.exports = require('@feathersjs/errors/handler');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const Proto = require('uberproto');
-const debug = require('debug')('feathersjs/express');
+const errorHandler = require('@feathersjs/errors/handler');
+const debug = require('debug')('@feathersjs/express');
 
 const rest = require('./rest');
 
@@ -75,4 +76,4 @@ module.exports = function feathersExpress (feathersApp) {
   return Proto.mixin(mixin, expressApp);
 };
 
-Object.assign(module.exports, express, { rest });
+Object.assign(module.exports, express, { rest, errorHandler });

--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -1,7 +1,7 @@
 const makeDebug = require('debug');
 const wrappers = require('./wrappers');
 
-const debug = makeDebug('feathersjs/express/rest');
+const debug = makeDebug('@feathersjs/express/rest');
 
 function formatter (req, res, next) {
   if (res.data === undefined) {

--- a/lib/rest/wrappers.js
+++ b/lib/rest/wrappers.js
@@ -1,7 +1,7 @@
 const errors = require('@feathersjs/errors');
 const { omit } = require('@feathersjs/commons')._;
 
-const debug = require('debug')('feathersjs/express/rest');
+const debug = require('debug')('@feathersjs/express/rest');
 
 const statusCodes = {
   created: 201,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,6 +12,11 @@ describe('@feathersjs/express', () => {
     }
   };
 
+  it('exports .rest and .errorHandler', () => {
+    assert.equal(typeof expressify.rest, 'function');
+    assert.equal(expressify.errorHandler, require('@feathersjs/errors/handler'));
+  });
+
   it('returns an Express application', () => {
     const app = expressify(feathers());
 


### PR DESCRIPTION
Since it should really live in this module not in `@feathersjs/errors` (we'll move it over later).