### PR TITLE
Allow to set HTTP status code in a hook

### DIFF
--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -20,11 +20,11 @@ function rest (handler = formatter) {
     const app = this;
 
     if (typeof app.route !== 'function') {
-      throw new Error('feathers-rest needs an Express compatible app. Feathers apps have to wrapped with feathers-express first.');
+      throw new Error('@feathersjs/express/rest needs an Express compatible app. Feathers apps have to wrapped with feathers-express first.');
     }
 
     if (!app.version || app.version < '3.0.0') {
-      throw new Error(`feathers-rest requires an instance of a Feathers application version 3.x or later (got ${app.version})`);
+      throw new Error(`@feathersjs/express/rest requires an instance of a Feathers application version 3.x or later (got ${app.version})`);
     }
 
     app.rest = wrappers;

--- a/lib/rest/wrappers.js
+++ b/lib/rest/wrappers.js
@@ -64,7 +64,9 @@ function getHandler (method, getArgs) {
           res.data = data;
           res.hook = hook;
 
-          if (!data) {
+          if (hook.statusCode) {
+            res.status(hook.statusCode);
+          } else if (!data) {
             debug(`No content returned for '${req.url}'`);
             res.status(statusCodes.noContent);
           } else if (method === 'create') {

--- a/test/rest/index.test.js
+++ b/test/rest/index.test.js
@@ -18,7 +18,7 @@ describe('@feathersjs/express/rest provider', () => {
         app.configure(rest());
         assert.ok(false, 'Should never get here');
       } catch (e) {
-        assert.equal(e.message, 'feathers-rest needs an Express compatible app. Feathers apps have to wrapped with feathers-express first.');
+        assert.equal(e.message, '@feathersjs/express/rest needs an Express compatible app. Feathers apps have to wrapped with feathers-express first.');
       }
     });
 
@@ -31,7 +31,7 @@ describe('@feathersjs/express/rest provider', () => {
 
         assert.ok(false, 'Should never get here');
       } catch (e) {
-        assert.equal(e.message, 'feathers-rest requires an instance of a Feathers application version 3.x or later (got 2.9.9)');
+        assert.equal(e.message, '@feathersjs/express/rest requires an instance of a Feathers application version 3.x or later (got 2.9.9)');
       }
     });
 
@@ -181,6 +181,23 @@ describe('@feathersjs/express/rest provider', () => {
               fromDispatch: true
             });
           });
+      });
+
+      it('allows to set statusCode in a hook', () => {
+        app.use('/hook-status', {
+          get (id) {
+            return Promise.resolve({});
+          }
+        });
+
+        app.service('hook-status').hooks({
+          after (hook) {
+            hook.statusCode = 206;
+          }
+        });
+
+        return axios.get('http://localhost:4777/hook-status/dishes')
+          .then(res => assert.equal(res.status, 206));
       });
 
       it('sets the hook object in res.hook on error', () => {


### PR DESCRIPTION
So that the built-in status codes can be overwritten.